### PR TITLE
docs: remove timeout flag from running

### DIFF
--- a/content/guide/running.md
+++ b/content/guide/running.md
@@ -26,11 +26,6 @@ These flags are identical. Using them runs the project only on virtual devices.
 
 Only run on the specified device. The id is taken from the output of [`ns devices`](/guide/cli-basics#listing-connected-devices).
 
-#### --timeout &lt;seconds&gt;
-
-The number of seconds to wait for the debugger to boot.
-The default timeout is 90 seconds.
-
 #### --clean
 
 Forces a clean rebuild of the native application.


### PR DESCRIPTION
This flag should not go here because I think this is not only for `ns debug` and not for `ns run`
In this section if it makes sense https://beta.docs.nativescript.org/guide/debugging#debugging-with-chrome-devtools