### PR TITLE
fix: update note about what `clean` command removes and config reference link

### DIFF
--- a/content/guide/cli-basics.md
+++ b/content/guide/cli-basics.md
@@ -3,6 +3,7 @@ title: CLI Basics
 contributors:
   - Ombuweb
   - rigor789
+  - achou11
 ---
 
 When working with NativeScript, you will often interact with the NativeScript CLI. The CLI is self-documented, so you can always run `ns --help` or `ns <command> --help` to view available commands, flags and descriptions.

--- a/content/guide/cli-basics.md
+++ b/content/guide/cli-basics.md
@@ -28,7 +28,7 @@ To clean, run this command from your project's root directory:
 ns clean
 ```
 
-Running `ns clean` removes the `node_modules`, `hooks`, and `platforms` directories. You can customize what's cleaned in the [nativescript.config.ts](/project-structure/nativescript-config#cli-pathstoclean).
+Running `ns clean` removes the `node_modules`, `hooks`, and `platforms` directories and the `package-lock.json` file. You can customize what's cleaned in the [nativescript.config.ts](/configuration/nativescript#cli-pathstoclean).
 
 ### Cleaning multiple projects
 


### PR DESCRIPTION
Noticed that the docs were missing a note about also removing the `package-lock.json` file and that the link for the reference doesn't actually take you to the `cli.pathsToClean` reference page.

https://github.com/NativeScript/nativescript-cli/blob/3d5891a1682a39b0ce93c72b49962b1e20ed7cbd/lib/commands/clean.ts#L113