### PR TITLE
chore: ListView item loading event typo

### DIFF
--- a/content/ui/list-view.md
+++ b/content/ui/list-view.md
@@ -164,10 +164,10 @@ Emitted when a user taps an item in the ListView.
 
 See [ItemEventData](/api/interface/ItemEventData).
 
-### itemsLoading
+### itemLoading
 
 ```ts
-on('itemsLoading', (args: ItemEventData) => {
+on('itemLoading', (args: ItemEventData) => {
   const listView = args.object as ListView
 })
 ```


### PR DESCRIPTION
Just a small correction for a ListView event.