### PR TITLE
fix: update windows default JDK path

### DIFF
--- a/content/setup/windows.md
+++ b/content/setup/windows.md
@@ -63,7 +63,7 @@ If you see a version number printed, you are ready to move on to [Installing And
 4. Click **New** and add the **JDK binaries folder** path to the list.
    The default location is
    ```
-   %LOCALAPPDATA%\???
+   C:\Program Files\Eclipse Adoptium\jdk-17.X.X\bin
    ```
 
 ### Installing Android Studio


### PR DESCRIPTION
Do we have a standard for displaying transient external version numbers?

I've used the following format to display the path:
```
C:\Program Files\Eclipse Adoptium\jdk-17.X.X\bin
```

However, the actual path is:
```
C:\Program Files\Eclipse Adoptium\jdk-17.0.11.9-hotspot\bin
```