### PR TITLE
Reflect requirement for JAVA_HOME with temurin17

### DIFF
--- a/content/setup/windows.md
+++ b/content/setup/windows.md
@@ -55,7 +55,7 @@ Once installed, you might need to add it to your `Path`. First, check if you nee
 javac --version
 ```
 
-If you see a version number printed, you are ready to move on to [Installing Android Studio](#installing-android-studio), otherwise you will need to add the JDK binaries to your system environment `Path`:
+If you see a version number printed, you may skip this step. Otherwise, you will need to add the JDK binaries to your system environment `Path`:
 
 1. Search for "**Edit the system environment variables**" in Windows Search and select
 2. Click on "**Environment variables...**" in the bottom corner
@@ -65,6 +65,18 @@ If you see a version number printed, you are ready to move on to [Installing And
    ```
    C:\Program Files\Eclipse Adoptium\jdk-17.X.X\bin
    ```
+   
+Additionally, some installations may require creating the `JAVA_HOME` environment variable manually:
+1. Search for "**Edit the system environment variables**" in Windows Search and select
+2. Click on "**Environment variables...**" in the bottom corner
+3. Click on **New...** under the "**User variables for...**" section
+4. Add the following variable. Ensure you're using the correct JDK path. Example:
+   ```
+   VARIABLE_NAME: JAVA_HOME
+   VARIABLE_VALUE: C:\Program Files\Eclipse Adoptium\jdk-17.0.12.7-hotspot
+   ```
+
+You may need to restart your terminal for changes to apply.
 
 ### Installing Android Studio
 

--- a/content/setup/windows.md
+++ b/content/setup/windows.md
@@ -70,7 +70,7 @@ Additionally, some installations may require creating the `JAVA_HOME` environmen
 1. Search for "**Edit the system environment variables**" in Windows Search and select
 2. Click on "**Environment variables...**" in the bottom corner
 3. Click on **New...** under the "**User variables for...**" section
-4. Add the following variable. Ensure you're using the correct JDK path. Example:
+4. Add the following variable. Ensure you're using the correct JDK path, without the \bin suffix. Example:
    ```
    VARIABLE_NAME: JAVA_HOME
    VARIABLE_VALUE: C:\Program Files\Eclipse Adoptium\jdk-17.0.12.7-hotspot


### PR DESCRIPTION
When I follow the Windows setup tutorial for Android on a clean install, using OpenJDK 17 through chocolatey as suggested, doctor fails to detect the location then advises to follow the tutorial or set the JAVA_HOME environment variable. 

For context, the error message is as follows:
```
Error executing command 'javac'. Make sure you have installed The Java Development Kit (JDK) and set JAVA_HOME environment variable.
 You will not be able to build your projects for Android.
To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as
 described in https://docs.nativescript.org/setup
```

The tutorial only instructs to add the **binaries** to PATH and can lead to confusion for new users, as JAVA_HOME expects the parent directory instead. After correctly setting the variable, the rest of the setup completes successfully.

I have updated the documentation to reflect this requirement.

