### PR TITLE
Add linkTap event to Label page

### DIFF
--- a/content/ui/label.md
+++ b/content/ui/label.md
@@ -73,6 +73,16 @@ If you need to style parts of the text, you can use a combination of a `Formatte
 </Label>
 ```
 
+#### Span linkTap event
+
+Tap event for Span.
+
+```ts
+on('linkTap', (data: EventData) => {
+  console.log('Span tapped')
+})
+```
+
 ## Props
 
 ### letterSpacing


### PR DESCRIPTION
I've added the linkTap event as this is not documented anywhere and was discovered here https://discord.com/channels/603595811204366337/606457523574407178/1345685959416614963

<!-- insert PR description above this comment -->
-----
<a href="https://stackblitz.com/~/github.com/vallemar/docs/tree/web-publisher/vallemar/label.md"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz next generation editor" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)._