### PR TITLE
Fix typos choosing-an-editor.md

### DIFF
--- a/content/guide/choosing-an-editor.md
+++ b/content/guide/choosing-an-editor.md
@@ -16,9 +16,9 @@ If you do choose to [try Visual Studio Code](https://code.visualstudio.com/), le
 
 After you install Visual Studio Code, you can open projects using the editor's `File` → `Open` menu option, but there's an alternative option that works far better for command-line-based projects like NativeScript: the `code` command.
 
-The `code` command runs in your command-line or terminal, and it works just like the `ns` command does for NativeScript apps. Visual Studio Code installs the `code` command by default on Windows on Linux, but on macOS, there's [one manual step](https://code.visualstudio.com/docs/setup/mac) you must perform.
+The `code` command runs in your command-line or terminal, and it works just like the `ns` command does for NativeScript apps. Visual Studio Code installs the `code` command by default on Windows and Linux, but on macOS, there's [one manual step](https://code.visualstudio.com/docs/setup/mac) you must perform.
 
-Once set up, you can type `code .` in your terminal to open the files in your current folder for editing. For example, you could use the following sequence of command to create a new NativeScript app and open it for editing.
+Once set up, you can type `code .` in your terminal to open the files in your current folder for editing. For example, you could use the following sequence of commands to create a new NativeScript app and open it for editing.
 
 ```bash
 ns create MyNewApp


### PR DESCRIPTION
- Changed 'Visual Studio Code installs the code command by default on Windows on Linux...' to 'Windows and Linux' 

- Changed 'sequence of command' to 'sequence of commands' for better clarity.
Related Issue: #174 