### PR TITLE
fix: update android sdk path on windows

### DIFF
--- a/content/setup/windows.md
+++ b/content/setup/windows.md
@@ -108,7 +108,7 @@ The SDK is by default located at:
 %LOCALAPPDATA%\Android\Sdk
 ```
 
-To find the actual location in the Android Studio **Settings**, navigate to **Appearance & Behavior › System Settings › Android SDK** and copy the Android SDK Location.
+To find the actual location in the Android Studio **Settings**, navigate to **Languages & Frameworks › Android SDK** and copy the Android SDK Location.
 
 Next, add Android **platform-tools** to path:
 


### PR DESCRIPTION
In newer versions of Android Studio on Windows, this Path has been moved out of the Appearance section and into the Languages & Frameworks section.

Screenshot for reference:

<img width="987" height="735" alt="image" src="https://github.com/user-attachments/assets/f015cee3-fbdb-49a7-87ba-2473728bab01" />

---

Taken from:
```text
Android Studio Narwhal | 2025.1.1 Patch 1
Build #AI-251.25410.109.2511.13752376, built on July 9, 2025
Runtime version: 21.0.6+-13391695-b895.109 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Toolkit: sun.awt.windows.WToolkit
Windows 11.0
GC: G1 Young Generation, G1 Concurrent GC, G1 Old Generation
Memory: 2048M
Cores: 16
Registry:
  ide.experimental.ui=true
  com.android.studio.ml.activeModel=com.android.studio.ml.AidaModel
```